### PR TITLE
Fixes a race condition that can happen when timers are used as tickers

### DIFF
--- a/fakeclock/fake_timer.go
+++ b/fakeclock/fake_timer.go
@@ -47,7 +47,6 @@ func (ft *fakeTimer) Reset(d time.Duration) bool {
 func (ft *fakeTimer) Stop() bool {
 	ft.mutex.Lock()
 	active := !ft.completionTime.IsZero()
-	ft.completionTime = time.Time{}
 	ft.mutex.Unlock()
 
 	ft.clock.removeTimeWatcher(ft)


### PR DESCRIPTION
This race condition is only relevant if a timer is used as a ticker, for
example:

```
select <- timer.C():
  do.Something()
  ..
  timer.Reset(someInterval)
```

The added tests fails randomly, usually within a few runs of `ginkgo -untilItFails`

[#130238495]

Signed-off-by: John Shahid <jvshahid@gmail.com>