### PR TITLE
Add Clock#After

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -6,6 +6,13 @@ type Clock interface {
 	Now() time.Time
 	Sleep(d time.Duration)
 	Since(t time.Time) time.Duration
+	// After waits for the duration to elapse and then sends the current time
+	// on the returned channel.
+	// It is equivalent to clock.NewTimer(d).C.
+	// The underlying Timer is not recovered by the garbage collector
+	// until the timer fires. If efficiency is a concern, use clock.NewTimer
+	// instead and call Timer.Stop if the timer is no longer needed.
+	After(d time.Duration) <-chan time.Time
 
 	NewTimer(d time.Duration) Timer
 	NewTicker(d time.Duration) Ticker
@@ -27,6 +34,10 @@ func (clock *realClock) Since(t time.Time) time.Duration {
 
 func (clock *realClock) Sleep(d time.Duration) {
 	<-clock.NewTimer(d).C()
+}
+
+func (clock *realClock) After(d time.Duration) <-chan time.Time {
+	return clock.NewTimer(d).C()
 }
 
 func (clock *realClock) NewTimer(d time.Duration) Timer {

--- a/fakeclock/fake_clock.go
+++ b/fakeclock/fake_clock.go
@@ -64,6 +64,10 @@ func (clock *FakeClock) Sleep(d time.Duration) {
 	<-clock.NewTimer(d).C()
 }
 
+func (clock *FakeClock) After(d time.Duration) <-chan time.Time {
+	return clock.NewTimer(d).C()
+}
+
 func (clock *FakeClock) NewTicker(d time.Duration) clock.Ticker {
 	timer := newFakeTimer(clock, d, true)
 	clock.addTimeWatcher(timer)

--- a/fakeclock/fake_clock_test.go
+++ b/fakeclock/fake_clock_test.go
@@ -49,6 +49,25 @@ var _ = Describe("FakeClock", func() {
 		})
 	})
 
+	Describe("After", func() {
+		It("waits and then sends the current time on the returned channel", func() {
+			timeChan := fakeClock.After(10 * time.Second)
+			Consistently(timeChan, Δ).ShouldNot(Receive())
+
+			fakeClock.Increment(5 * time.Second)
+			Consistently(timeChan, Δ).ShouldNot(Receive())
+
+			fakeClock.Increment(4 * time.Second)
+			Consistently(timeChan, Δ).ShouldNot(Receive())
+
+			fakeClock.Increment(1 * time.Second)
+			Eventually(timeChan).Should(Receive(Equal(initialTime.Add(10 * time.Second))))
+
+			fakeClock.Increment(10 * time.Second)
+			Consistently(timeChan, Δ).ShouldNot(Receive())
+		})
+	})
+
 	Describe("WatcherCount", func() {
 		Context("when a timer is created", func() {
 			It("increments the watcher count", func() {


### PR DESCRIPTION
When readability is more desirable than performance, see:
https://golang.org/pkg/time/#After