### PR TITLE
Don't allow fake tickers with non-positive periods.

### DIFF
--- a/fakeclock/fake_clock.go
+++ b/fakeclock/fake_clock.go
@@ -1,6 +1,7 @@
 package fakeclock
 
 import (
+	"errors"
 	"sync"
 	"time"
 
@@ -71,6 +72,10 @@ func (clock *FakeClock) After(d time.Duration) <-chan time.Time {
 }
 
 func (clock *FakeClock) NewTicker(d time.Duration) clock.Ticker {
+	if d <= 0 {
+		panic(errors.New("duration must be greater than zero"))
+	}
+
 	timer := newFakeTimer(clock, d, true)
 	clock.addTimeWatcher(timer)
 

--- a/fakeclock/fake_ticker_test.go
+++ b/fakeclock/fake_ticker_test.go
@@ -55,4 +55,8 @@ var _ = Describe("FakeTicker", func() {
 		fakeClock.Increment(0)
 		Consistently(ticker.C()).ShouldNot(Receive())
 	})
+
+	It("panics given an invalid duration", func() {
+		Expect(func() { fakeClock.NewTicker(0) }).Should(Panic())
+	})
 })

--- a/fakeclock/fake_timer.go
+++ b/fakeclock/fake_timer.go
@@ -13,7 +13,6 @@ type fakeTimer struct {
 	channel        chan time.Time
 	duration       time.Duration
 	repeat         bool
-	lastFireTime   time.Time
 }
 
 func newFakeTimer(clock *FakeClock, d time.Duration, repeat bool) *fakeTimer {
@@ -62,8 +61,6 @@ func (ft *fakeTimer) shouldFire(now time.Time) bool {
 	if ft.completionTime.IsZero() {
 		return false
 	}
-
-	ft.lastFireTime = now
 
 	return now.After(ft.completionTime) || now.Equal(ft.completionTime)
 }


### PR DESCRIPTION
Calling fakeclock.NewTicker(0) causes the stack to overflow.
Panic instead, which is what time.NewTicker() does.